### PR TITLE
Make bcl2fastq write and use another samplesheet

### DIFF
--- a/bcl2fastq/handlers/bcl2fastq_handlers.py
+++ b/bcl2fastq/handlers/bcl2fastq_handlers.py
@@ -98,6 +98,7 @@ class StartHandler(BaseBcl2FastqHandler, Bcl2FastqServiceMixin):
         # TODO Make sure to escape them for sec. reasons.
         bcl2fastq_version = ""
         runfolder_input = ""
+        samplesheet = ""
         output = ""
         barcode_mismatches = ""
         tiles = ""
@@ -116,6 +117,9 @@ class StartHandler(BaseBcl2FastqHandler, Bcl2FastqServiceMixin):
         if "output" in request_data:
             output = request_data["output"]
 
+        if "samplesheet" in request_data:
+            samplesheet = request_data["samplesheet"]
+
         if "barcode_mismatches" in request_data:
             barcode_mismatches = request_data["barcode_mismatches"]
 
@@ -133,6 +137,7 @@ class StartHandler(BaseBcl2FastqHandler, Bcl2FastqServiceMixin):
             bcl2fastq_version,
             runfolder_input,
             output,
+            samplesheet,
             barcode_mismatches,
             tiles,
             use_base_mask,
@@ -147,6 +152,7 @@ class StartHandler(BaseBcl2FastqHandler, Bcl2FastqServiceMixin):
         can contain one or more of the following parameters:
          - bcl2fastq_version
          - output
+         - samplesheet (provide the entire samplesheet in the request)
          - barcode_mismatches
          - tiles
          - use_base_mask

--- a/bcl2fastq/handlers/bcl2fastq_handlers.py
+++ b/bcl2fastq/handlers/bcl2fastq_handlers.py
@@ -202,7 +202,7 @@ class StartHandler(BaseBcl2FastqHandler, Bcl2FastqServiceMixin):
             self.set_status(202, reason="started processing")
             self.write_json(response_data)
         except RuntimeError as e:
-            log.warning("Failed starting {}. Message: ".format(runfolder, e.message))
+            log.warning("Failed starting {0}. Message: {1}".format(runfolder, e.message))
             self.send_error(status_code=500, reason=e.message)
 
 

--- a/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/lib/bcl2fastq_utils.py
@@ -21,6 +21,7 @@ class Bcl2FastqConfig:
                  bcl2fastq_version,
                  runfolder_input,
                  output,
+                 samplesheet=None,
                  barcode_mismatches=None,
                  tiles=None,
                  use_base_mask=None,
@@ -33,6 +34,9 @@ class Bcl2FastqConfig:
         :param bcl2fastq_version: version of bcl2fastq to run
         :param runfolder_input: the path to the runfolder to run bcl2fastq on
         :param output: where the output of bcl2fastq should be placed
+        :param samplesheet: a samplesheet as a raw string - if none is provided the samplesheet in the
+                            runfolder will be used. If it is specified this provided string will be
+                            written to a file and passed to bcl2fastq.
         :param barcode_mismatches: how many mismatches to allow in tag.
         :param tiles: tiles to include when running bcl2fastq
         :param use_base_mask: base mask to use
@@ -41,8 +45,15 @@ class Bcl2FastqConfig:
         """
 
         self.runfolder_input = runfolder_input
-        self.samplesheet_file = runfolder_input + "/SampleSheet.csv"
         self.base_calls_input = runfolder_input + "/Data/Intensities/BaseCalls"
+
+        if not samplesheet:
+            self.samplesheet_file = runfolder_input + "/SampleSheet.csv"
+        else:
+            log.debug("Got a new samplesheet. Will use that instead of the one found in the runfolder.")
+            new_samplesheet_file = runfolder_input + "/arteria_samplesheet.csv"
+            Bcl2FastqConfig.write_samplesheet(samplesheet, new_samplesheet_file)
+            self.samplesheet_file = new_samplesheet_file
 
         if bcl2fastq_version:
             self.bcl2fastq_version = bcl2fastq_version
@@ -71,6 +82,11 @@ class Bcl2FastqConfig:
         else:
             import multiprocessing
             self.nbr_of_cores = multiprocessing.cpu_count()
+
+    @staticmethod
+    def write_samplesheet(samplesheet_string, new_samplesheet_file):
+        with open(new_samplesheet_file, "w") as f:
+                f.write(samplesheet_string)
 
     @staticmethod
     def get_bcl2fastq_version_from_run_parameters(runfolder, config):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,37 @@ class TestUtils:
                           "NextSeq 500": {"bcl2fastq_version": "1.8.4"}},
                      "bcl2fastq_logs_path": "/tmp/"}
 
+    DUMMY_SAMPLESHEET_STRING =  """[Header],,,,,,,,,,,
+IEMFileVersion,4,,,,,,,,,,
+Experiment Name,Hiseq-2500-dual-index,,,,,,,,,,
+Date,8/13/2015,,,,,,,,,,
+Workflow,Resequencing,,,,,,,,,,
+Application,Human Genome Resequencing,,,,,,,,,,
+Assay,TruSeq HT,,,,,,,,,,
+Description,,,,,,,,,,,
+Chemistry,Amplicon,,,,,,,,,,
+,,,,,,,,,,,
+[Reads],,,,,,,,,,,
+151,,,,,,,,,,,
+151,,,,,,,,,,,
+,,,,,,,,,,,
+[Settings],,,,,,,,,,,
+FlagPCRDuplicates,1,,,,,,,,,,
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA,,,,,,,,,,
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT,,,,,,,,,,
+,,,,,,,,,,,
+[Data],,,,,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description,GenomeFolder
+1,1,1,,,D701,ATTACTCG,D501,TATAGCCT,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+2,2,2,,,D702,TCCGGA,D503,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+3,3,3,,,D703,CGCTCA,D503,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+4,4,4,,,D704,GAGATTC,D504,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+5,5,5,,,D705,ATTCAGA,D505,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+6,6,6,,,D706,GAATTCG,D506,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+7,7,7,,,D707,CTGAAGC,D507,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+8,8,8,,,D708,TAATGCG,D508,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta"""
+
+
 class DummyConfig:
     def __getitem__(self, key):
         return TestUtils.DUMMY_CONFIG[key]

--- a/tests/tests_bcl2fastq_utils.py
+++ b/tests/tests_bcl2fastq_utils.py
@@ -124,12 +124,13 @@ class TestBCL2Fastq2xRunner(unittest.TestCase):
         runner = BCL2Fastq2xRunner(config, "/bcl/binary/path")
         command = runner.construct_command()
         expected_command = "/bcl/binary/path --input-dir test/runfolder/Data/Intensities/BaseCalls " \
-                           "--output-dir test/output --barcode-mismatches 2 " \
+                           "--output-dir test/output " \
+                           "--sample-sheet test/runfolder/SampleSheet.csv " \
+                           "--barcode-mismatches 2 " \
                            "--tiles s1,s2,s3 " \
                            "--use-bases-mask y*,i6,i6,y* --use-bases-mask 1:y*,i5,i5,y* " \
                            "--my-best-arg 1 --my-best-arg 2"
         self.assertEqual(command, expected_command)
-
 
 class TestBCL2FastqRunner(unittest.TestCase):
 


### PR DESCRIPTION
If a samplesheet is provided in the request (as a raw string) this will be parsed and written to a file and then passed to bcl2fastq.
