### PR TITLE
Fix symlink creation

### DIFF
--- a/bcl2fastq/handlers/bcl2fastq_handlers.py
+++ b/bcl2fastq/handlers/bcl2fastq_handlers.py
@@ -170,6 +170,7 @@ class StartHandler(BaseBcl2FastqHandler, Bcl2FastqServiceMixin):
                 create_bcl2fastq_runner(runfolder_config)
             bcl2fastq_version = job_runner.version()
             cmd = job_runner.construct_command()
+            job_runner.symlink_output_to_unaligned()
 
             log_base_path = self.config["bcl2fastq_logs_path"]
             log_file = "{0}/{1}.log".format(log_base_path, runfolder)

--- a/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/lib/bcl2fastq_utils.py
@@ -262,7 +262,6 @@ class BCL2FastqRunner(object):
     def symlink_output_to_unaligned(self):
         """
         Create a symlink from `runfolder/Unaligned` to what has been defined as the output directory.
-        :return: None
         :raises: OSError if there was any problem creating the symlink, except for that it was already
                          there, in which case, do nothing.
         """
@@ -271,17 +270,16 @@ class BCL2FastqRunner(object):
 
         try:
             log.debug("Create symlink from {} to {}.".
-                        format(link_path,
-                               link_target_path))
+                      format(link_path,
+                             link_target_path))
             os.symlink(link_target_path, link_path)
-            return None
         except OSError as e:
             if e.errno == os.errno.EEXIST:
                 log.warning("Symlink from {} to {} already exits, will remove it and recreate it...".
                             format(link_path, link_target_path))
                 log.warning("Removing link: {}".format(link_path))
                 os.remove(link_path)
-                self.symlink_output_to_unaligned()
+                os.symlink(link_target_path, link_path)
             else:
                 log.error("Problem creating symlink from {} to {}. Message: {}".
                           format(link_path, link_target_path, e.message))

--- a/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/lib/bcl2fastq_utils.py
@@ -266,22 +266,25 @@ class BCL2FastqRunner(object):
         :raises: OSError if there was any problem creating the symlink, except for that it was already
                          there, in which case, do nothing.
         """
+        link_path = self.config.runfolder_input + "/Unaligned"
+        link_target_path = self.config.output
+
         try:
             log.debug("Create symlink from {} to {}.".
-                        format(self.config.runfolder_input + "/Unaligned",
-                               self.config.output))
-            os.symlink(self.config.output, self.config.runfolder_input + "/Unaligned")
+                        format(link_path,
+                               link_target_path))
+            os.symlink(link_target_path, link_path)
             return None
         except OSError as e:
             if e.errno == os.errno.EEXIST:
-                log.warning("Symlink from {} to {} already exits, will not recreate it...".
-                            format(self.config.runfolder_input + "/Unaligned",
-                                   self.config.output))
+                log.warning("Symlink from {} to {} already exits, will remove it and recreate it...".
+                            format(link_path, link_target_path))
+                log.warning("Removing link: {}".format(link_path))
+                os.remove(link_path)
+                self.symlink_output_to_unaligned()
             else:
                 log.error("Problem creating symlink from {} to {}. Message: {}".
-                          format(self.config.runfolder_input + "/Unaligned",
-                                 self.config.output,
-                                 e.message))
+                          format(link_path, link_target_path, e.message))
                 raise e
 
 

--- a/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/lib/bcl2fastq_utils.py
@@ -267,6 +267,9 @@ class BCL2FastqRunner(object):
                          there, in which case, do nothing.
         """
         try:
+            log.debug("Create symlink from {} to {}.".
+                        format(self.config.runfolder_input + "/Unaligned",
+                               self.config.output))
             os.symlink(self.config.output, self.config.runfolder_input + "/Unaligned")
             return None
         except OSError as e:
@@ -280,28 +283,6 @@ class BCL2FastqRunner(object):
                                  self.config.output,
                                  e.message))
                 raise e
-
-    def run(self):
-        """
-        Will run the command provided by `_construct_command` and
-        create a soft link from the runfolder in question, to the
-         output directory, named Unaligned. E.g.
-            /path/to/runfolder/Unaligned -> /path/to/output
-        :return: True is successfully run, else False.
-        """
-
-        self.symlink_output_to_unaligned()
-        self.command = self.construct_command()
-        log.debug("Running bcl2fastq with command: " + self.command)
-
-        try:
-            output = subprocess.check_call(self.command, shell=True, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as exc:
-            log.warning("Failure in running bcl2fastq: {}".format(exc.message))
-            return False
-        else:
-            log.info("Successfully finished running bcl2fastq!")
-            return True
 
 
 class BCL2Fastq2xRunner(BCL2FastqRunner):

--- a/tests/test_bcl2fastq_handlers.py
+++ b/tests/test_bcl2fastq_handlers.py
@@ -6,7 +6,7 @@ from test_utils import TestUtils, DummyConfig
 
 
 from bcl2fastq.handlers.bcl2fastq_handlers import *
-from bcl2fastq.lib.bcl2fastq_utils import BCL2Fastq2xRunner
+from bcl2fastq.lib.bcl2fastq_utils import BCL2Fastq2xRunner, BCL2FastqRunner
 from bcl2fastq.app import routes
 from tornado.web import Application
 from test_utils import FakeRunner
@@ -49,7 +49,8 @@ class TestBcl2FastqHandlers(AsyncHTTPTestCase):
         # creating the runfolder.
         with mock.patch.object(os.path, 'isdir', return_value=True), \
              mock.patch.object(Bcl2FastqConfig, 'get_bcl2fastq_version_from_run_parameters', return_value="2.15.2"), \
-             mock.patch.object(BCL2FastqRunnerFactory, "create_bcl2fastq_runner", return_value=FakeRunner("2.15.2")):
+             mock.patch.object(BCL2FastqRunnerFactory, "create_bcl2fastq_runner", return_value=FakeRunner("2.15.2")), \
+             mock.patch.object(BCL2FastqRunner, 'symlink_output_to_unaligned', return_value=None):
 
             body = {"runfolder_input": "/path/to/runfolder"}
             response = self.fetch(
@@ -69,7 +70,8 @@ class TestBcl2FastqHandlers(AsyncHTTPTestCase):
         # creating the runfolder.
         with mock.patch.object(os.path, 'isdir', return_value=True), \
              mock.patch.object(Bcl2FastqConfig, 'get_bcl2fastq_version_from_run_parameters', return_value="2.15.2"), \
-             mock.patch.object(BCL2FastqRunnerFactory, "create_bcl2fastq_runner", return_value=FakeRunner("2.15.2")):
+             mock.patch.object(BCL2FastqRunnerFactory, "create_bcl2fastq_runner", return_value=FakeRunner("2.15.2")), \
+             mock.patch.object(BCL2FastqRunner, 'symlink_output_to_unaligned', return_value=None):
 
             response = self.fetch(self.API_BASE + "/start/150415_D00457_0091_AC6281ANXX", method="POST", body="")
 
@@ -87,8 +89,9 @@ class TestBcl2FastqHandlers(AsyncHTTPTestCase):
         # creating the runfolder.
         with mock.patch.object(os.path, 'isdir', return_value=True), \
              mock.patch.object(Bcl2FastqConfig, 'get_bcl2fastq_version_from_run_parameters', return_value="2.15.2"), \
-             mock.patch.object(Bcl2FastqConfig, "write_samplesheet") as ws ,\
-             mock.patch.object(BCL2FastqRunnerFactory, "create_bcl2fastq_runner", return_value=FakeRunner("2.15.2")):
+             mock.patch.object(BCL2FastqRunner, 'symlink_output_to_unaligned', return_value=None), \
+             mock.patch.object(Bcl2FastqConfig, "write_samplesheet") as ws , \
+                mock.patch.object(BCL2FastqRunnerFactory, "create_bcl2fastq_runner", return_value=FakeRunner("2.15.2")):
 
             body = {"runfolder_input": "/path/to/runfolder", "samplesheet": TestUtils.DUMMY_SAMPLESHEET_STRING}
 

--- a/tests/tests_bcl2fastq_utils.py
+++ b/tests/tests_bcl2fastq_utils.py
@@ -157,32 +157,24 @@ class TestBCL2FastqRunner(unittest.TestCase):
         with patch.object(os, 'symlink', return_value=None) as m:
             dummy_runner = self.DummyBCL2FastqRunner(TestBCL2FastqRunner.config, None, None)
             dummy_runner.symlink_output_to_unaligned()
-            m.assert_called_with(TestBCL2FastqRunner.config.output, TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
+            m.assert_called_with(
+                TestBCL2FastqRunner.config.output,
+                TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
 
         # Check that trying to create an already existing softlink doesn't break the function.
         with patch.object(os, 'symlink', side_effect=OSError(17, "message")) as m:
             dummy_runner = self.DummyBCL2FastqRunner(TestBCL2FastqRunner.config, None, None)
             dummy_runner.symlink_output_to_unaligned()
-            m.assert_called_with(TestBCL2FastqRunner.config.output, TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
+            m.assert_called_with(TestBCL2FastqRunner.config.output,
+                                 TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
 
         # While any other error should
         with patch.object(os, 'symlink', side_effect=OSError()) as m:
             with self.assertRaises(OSError):
                 dummy_runner = self.DummyBCL2FastqRunner(TestBCL2FastqRunner.config, None, None)
                 dummy_runner.symlink_output_to_unaligned()
-                m.assert_called_with(TestBCL2FastqRunner.config.output, TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
-
-    def test__successful_run(self):
-        with patch.object(BCL2FastqRunner, 'symlink_output_to_unaligned', return_value=None) as m:
-            dummy_runner = self.DummyBCL2FastqRunner(TestBCL2FastqRunner.config, None, "echo 'high tech low life'; exit 0")
-            success = dummy_runner.run()
-            self.assertTrue(success)
-
-    def test__unsuccessful_run(self):
-        with patch.object(BCL2FastqRunner, 'symlink_output_to_unaligned', return_value=None) as m:
-            dummy_runner = self.DummyBCL2FastqRunner(TestBCL2FastqRunner.config, None,  "echo 'high tech low life'; exit 1")
-            success = dummy_runner.run()
-            self.assertFalse(success)
+                m.assert_called_with(TestBCL2FastqRunner.config.output,
+                                     TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
 
 class TestBCL2Fastq1xRunner(unittest.TestCase):
 

--- a/tests/tests_bcl2fastq_utils.py
+++ b/tests/tests_bcl2fastq_utils.py
@@ -162,15 +162,18 @@ class TestBCL2FastqRunner(unittest.TestCase):
                 TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
 
         # Check that trying to create an already existing softlink doesn't break the function.
-        with patch.object(os, 'remove', return_value=None), \
-             patch.object(os, 'symlink', side_effect=OSError(17, "message")) as m:
+        # Please note that the second side effect is None, which means that the second time th
+        # mock is called it will work.
+        with patch.object(os, 'remove', return_value=None) as r, \
+             patch.object(os, 'symlink', side_effect=[OSError(17, "message"), None]) as m:
             dummy_runner = self.DummyBCL2FastqRunner(TestBCL2FastqRunner.config, None, None)
             dummy_runner.symlink_output_to_unaligned()
             m.assert_called_with(TestBCL2FastqRunner.config.output,
                                  TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
+            r.assert_called_with(TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
 
         # While any other error should
-        with patch.object(os, 'symlink', side_effect=OSError()) as m:
+        with patch.object(os, 'symlink', side_effect=OSError(1, "message")) as m:
             with self.assertRaises(OSError):
                 dummy_runner = self.DummyBCL2FastqRunner(TestBCL2FastqRunner.config, None, None)
                 dummy_runner.symlink_output_to_unaligned()

--- a/tests/tests_bcl2fastq_utils.py
+++ b/tests/tests_bcl2fastq_utils.py
@@ -162,7 +162,8 @@ class TestBCL2FastqRunner(unittest.TestCase):
                 TestBCL2FastqRunner.config.runfolder_input + "/Unaligned")
 
         # Check that trying to create an already existing softlink doesn't break the function.
-        with patch.object(os, 'symlink', side_effect=OSError(17, "message")) as m:
+        with patch.object(os, 'remove', return_value=None), \
+             patch.object(os, 'symlink', side_effect=OSError(17, "message")) as m:
             dummy_runner = self.DummyBCL2FastqRunner(TestBCL2FastqRunner.config, None, None)
             dummy_runner.symlink_output_to_unaligned()
             m.assert_called_with(TestBCL2FastqRunner.config.output,


### PR DESCRIPTION
Removing `run` as to not confuse folks. That also mean moving the creation of the symlink to a new place. Finally I also decided that it would be better if the symlink was removed and recreated if it exits, as people might change output dirs between runs and in that case it would make sense to take the most recent one.
