### PR TITLE
Fixing NoIndex and single read support

### DIFF
--- a/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/lib/bcl2fastq_utils.py
@@ -155,7 +155,8 @@ class Bcl2FastqConfig:
             length_of_index_read = length_tuple[1]
             difference = length_of_index_read - length_of_index_in_samplesheet
 
-            assert difference >= 0, "Sample sheet indicates that index is longer than what was read by the sequencer!"
+            if not difference >= 0:
+                raise ValueError("Sample sheet indicates that index is longer than what was read by the sequencer!")
 
             if length_of_index_in_samplesheet == 0:
                 # If there is no index in the samplesheet, ignore it in the base-mask

--- a/tests/sampledata/no_tag_samplesheet_example.csv
+++ b/tests/sampledata/no_tag_samplesheet_example.csv
@@ -1,0 +1,29 @@
+[Header],,,,,,,,
+IEMFileVersion,4,,,,,,,
+Investigator Name,,,,,,,,
+Experiment Name,,,,,,,,
+Date,10/15/2015,,,,,,,
+Workflow,GenerateFASTQ,,,,,,,
+Application,HiSeq FASTQ Only,,,,,,,
+Assay,TruSeq LT,,,,,,,
+Description,,,,,,,,
+Chemistry,Default,,,,,,,
+,,,,,,,,
+[Reads],,,,,,,,
+151,,,,,,,,
+151,,,,,,,,
+,,,,,,,,
+[Settings],,,,,,,,
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA,,,,,,,
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT,,,,,,,
+,,,,,,,,
+[Data],,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+1,PhiX,PhiX,PhiX,,,,Test,PhiX
+2,PhiX,PhiX,PhiX,,,,Test,PhiX
+3,NA12878_100pM,NA12878_100pM,NA12878_100pM,,A016,CCGTCC,Test,NA12878_100pM
+4,NA12878_200pM,NA12878_200pM,NA12878_200pM,,A016,CCGTCC,Test,NA12878_200pM
+5,NA12878_300pM,NA12878_300pM,NA12878_300pM,,A016,CCGTCC,Test,NA12878_300pM
+6,NA12878_400pM,NA12878_400pM,NA12878_400pM,,A016,CCGTCC,Test,NA12878_400pM
+7,PhiX,PhiX,PhiX,,,,Test,PhiX
+8,PhiX,PhiX,PhiX,,,,Test,PhiX

--- a/tests/tests_bcl2fastq_utils.py
+++ b/tests/tests_bcl2fastq_utils.py
@@ -93,7 +93,7 @@ class TestBcl2FastqConfig(unittest.TestCase):
         mock_read_index_lengths = {2: 4, 3: 4}
         samplesheet = Samplesheet(TestBcl2FastqConfig.samplesheet_file)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             Bcl2FastqConfig. \
                 get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths, False)
 

--- a/tests/tests_bcl2fastq_utils.py
+++ b/tests/tests_bcl2fastq_utils.py
@@ -14,11 +14,20 @@ class TestBcl2FastqConfig(unittest.TestCase):
 
     test_dir = os.path.dirname(os.path.realpath(__file__))
     samplesheet_file = test_dir + "/sampledata/new_samplesheet_example.csv"
+    samplesheet_with_no_tag = test_dir + "/sampledata/no_tag_samplesheet_example.csv"
 
     def test_get_bcl2fastq_version_from_run_parameters(self):
         runfolder = TestBcl2FastqConfig.test_dir + "/sampledata/HiSeq-samples/2014-02_13_average_run"
         version = Bcl2FastqConfig.get_bcl2fastq_version_from_run_parameters(runfolder, TestUtils.DUMMY_CONFIG)
         self.assertEqual(version, "1.8.4")
+
+    def test_is_single_read_true(self):
+        runfolder = TestBcl2FastqConfig.test_dir + "/sampledata/HiSeq-samples/2014-02_13_average_run"
+        self.assertFalse(Bcl2FastqConfig.is_single_read(runfolder))
+
+    def test_is_single_read_false(self):
+        runfolder = TestBcl2FastqConfig.test_dir + "/sampledata/MiSeq-samples/2014-02_11_50kit_single_read"
+        self.assertTrue(Bcl2FastqConfig.is_single_read(runfolder))
 
     def test_get_length_of_indexes(self):
         runfolder = TestBcl2FastqConfig.test_dir + "/sampledata/HiSeq-samples/2014-02_13_average_run"
@@ -60,7 +69,23 @@ class TestBcl2FastqConfig(unittest.TestCase):
                                }
         samplesheet = Samplesheet(TestBcl2FastqConfig.samplesheet_file)
         actual_bases_mask = Bcl2FastqConfig. \
-            get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths)
+            get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths, False)
+        self.assertEqual(expected_bases_mask, actual_bases_mask)
+
+    def test_get_bases_mask_per_lane_from_samplesheet_single_read(self):
+        mock_read_index_lengths = {2: 9, 3: 9}
+        expected_bases_mask = {1: "y*,i8n*,i8n*",
+                               2: "y*,i6n*,n*",
+                               3: "y*,i6n*,n*",
+                               4: "y*,i7n*,n*",
+                               5: "y*,i7n*,n*",
+                               6: "y*,i7n*,n*",
+                               7: "y*,i7n*,n*",
+                               8: "y*,i7n*,n*",
+                               }
+        samplesheet = Samplesheet(TestBcl2FastqConfig.samplesheet_file)
+        actual_bases_mask = Bcl2FastqConfig. \
+            get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths, True)
         self.assertEqual(expected_bases_mask, actual_bases_mask)
 
     def test_get_bases_mask_per_lane_from_samplesheet_invalid_length_combo(self):
@@ -70,7 +95,24 @@ class TestBcl2FastqConfig(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             Bcl2FastqConfig. \
-                get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths)
+                get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths, False)
+
+    def test_get_bases_mask_per_lane_from_samplesheet_no_tag(self):
+        # If we don't have tag for one lane in the samplesheet.
+        mock_read_index_lengths = {2: 6}
+        expected_bases_mask = {1: "y*,n*,y*",
+                               2: "y*,n*,y*",
+                               3: "y*,i6,y*",
+                               4: "y*,i6,y*",
+                               5: "y*,i6,y*",
+                               6: "y*,i6,y*",
+                               7: "y*,n*,y*",
+                               8: "y*,n*,y*",
+                               }
+        samplesheet = Samplesheet(TestBcl2FastqConfig.samplesheet_with_no_tag)
+        actual_bases_mask = Bcl2FastqConfig. \
+            get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths, False)
+        self.assertEqual(expected_bases_mask, actual_bases_mask)
 
 
 class TestBCL2FastqRunnerFactory(unittest.TestCase):


### PR DESCRIPTION
This should fix #11.

I tried it out with https://bitbucket.org/brainstorm/gold_flowcell, e.g. `curl -X POST --data '{ "additional_args": "--ignore-missing-bcls --ignore-missing-filter --ignore-missing-positions --ignore-missing-controls", "tiles": "s_1"}' http://localhost:8888/api/1.0/start/gold_flowcell`

This will probably be a good base for deploying integration tests for this later.
