### PR TITLE
Log endpoint

### DIFF
--- a/bcl2fastq/app.py
+++ b/bcl2fastq/app.py
@@ -15,7 +15,8 @@ def routes(**kwargs):
         url(r"/api/1.0/versions", VersionsHandler, name="versions", kwargs=kwargs),
         url(r"/api/1.0/start/([\w_-]+)", StartHandler, name="start", kwargs=kwargs),
         url(r"/api/1.0/status/(\d*)", StatusHandler, name="status", kwargs=kwargs),
-        url(r"/api/1.0/stop/([\d|all]*)", StopHandler, name="stop", kwargs=kwargs)
+        url(r"/api/1.0/stop/([\d|all]*)", StopHandler, name="stop", kwargs=kwargs),
+        url(r"/api/1.0/logs/([\w_-]+)", Bcl2FastqLogHandler, name="logs", kwargs=kwargs)
     ]
 
 def start():

--- a/bcl2fastq/lib/bcl2fastq_logs.py
+++ b/bcl2fastq/lib/bcl2fastq_logs.py
@@ -1,0 +1,18 @@
+
+
+class Bcl2FastqLogFileProvider:
+
+    def __init__(self, config):
+        self.config = config
+
+    def log_file_path(self, runfolder):
+        log_base_path = self.config["bcl2fastq_logs_path"]
+        log_file = "{0}/{1}.log".format(log_base_path, runfolder)
+        return log_file
+
+    def get_log_for_runfolder(self, runfolder):
+        log_path = self.log_file_path(runfolder)
+        with open(log_path) as f:
+            file_content = f.read()
+        return file_content
+

--- a/tests/test_bcl2fastq_handlers.py
+++ b/tests/test_bcl2fastq_handlers.py
@@ -136,3 +136,7 @@ class TestBcl2FastqHandlers(AsyncHTTPTestCase):
             response = self.fetch(self.API_BASE + "/logs/coolest_runfolder", method="GET")
             self.assertEqual(response.code, 200)
             self.assertEqual(json.loads(response.body)["log"], "This is a string")
+
+    def test_get_logs_trying_to_reach_other_files(self):
+        response = self.fetch(self.API_BASE + "/logs/../../../etc/shadow", method="GET")
+        self.assertEqual(response.code, 404)

--- a/tests/test_bcl2fastq_handlers.py
+++ b/tests/test_bcl2fastq_handlers.py
@@ -7,6 +7,7 @@ from test_utils import TestUtils, DummyConfig
 
 from bcl2fastq.handlers.bcl2fastq_handlers import *
 from bcl2fastq.lib.bcl2fastq_utils import BCL2Fastq2xRunner, BCL2FastqRunner
+from bcl2fastq.lib.bcl2fastq_logs import Bcl2FastqLogFileProvider
 from bcl2fastq.app import routes
 from tornado.web import Application
 from test_utils import FakeRunner
@@ -129,3 +130,9 @@ class TestBcl2FastqHandlers(AsyncHTTPTestCase):
     def test_exception_stop_handler(self):
         response = self.fetch(self.API_BASE + "/stop/lll", method="POST", body = "")
         self.assertEqual(response.code, 500)
+
+    def test_get_logs(self):
+        with mock.patch.object(Bcl2FastqLogFileProvider, "get_log_for_runfolder", return_value="This is a string"):
+            response = self.fetch(self.API_BASE + "/logs/coolest_runfolder", method="GET")
+            self.assertEqual(response.code, 200)
+            self.assertEqual(json.loads(response.body)["log"], "This is a string")

--- a/tests/test_bcl2fastq_logs.py
+++ b/tests/test_bcl2fastq_logs.py
@@ -1,0 +1,35 @@
+
+import unittest
+from mock import MagicMock, patch, mock_open
+
+from bcl2fastq.lib.bcl2fastq_logs import Bcl2FastqLogFileProvider
+
+class TestBcl2FastqLogFileProvider(unittest.TestCase):
+
+    fake_file_content = """
+    This is a nice multi-line
+    string for
+    you
+    my friend
+    """
+    fake_path = "/fake/path"
+    mock_config = MagicMock()
+    mock_config.__getitem__.return_value = fake_path
+    runfolder = "160218_ST-E00215_0070_BHKGLFCCXX"
+
+    log_filer_provider = Bcl2FastqLogFileProvider(mock_config)
+
+    def test_log_file_path(self):
+        log_file = self.log_filer_provider.log_file_path(self.runfolder)
+        self.assertEqual(log_file, "{}/{}.log".format(self.fake_path, self.runfolder))
+
+    def test_get_log_for_runfolder(self):
+        with patch("__builtin__.open", mock_open(read_data=self.fake_file_content), create=True):
+            file_content = self.log_filer_provider.get_log_for_runfolder(self.runfolder)
+            self.assertEqual(file_content, self.fake_file_content)
+
+    def test_get_log_for_runfolder_does_not_exist(self):
+        with self.assertRaises(IOError):
+            self.log_filer_provider.get_log_for_runfolder(self.runfolder)
+
+


### PR DESCRIPTION
This new endpoint will allow the operator to access bcl2fastq logs by making a call along the lines of:

```
http://machine:port/api/1.0/logs/<runfolder_name>
```

This will return the content of the bcl2fastq log for that run. Pretty neat feature to have when debugging.
