### PR TITLE
Use latest arteria-core

### DIFF
--- a/requirements/prod
+++ b/requirements/prod
@@ -1,7 +1,7 @@
 jsonpickle==0.9.2
 tornado==4.2.1
 git+https://github.com/johandahlberg/localq.git@with_shell_true # Get from pip in future - localq
-git+https://github.com/arteria-project/arteria-core.git@v1.0.1#egg=arteria-core
+git+https://github.com/arteria-project/arteria-core.git@v1.1.0#egg=arteria-core
 illuminate==0.6.2
 pandas==0.14.1
 


### PR DESCRIPTION
This just bumps the version used for `arteria-core` to the latest available (1.1.0), that was released over a year ago.  :see_no_evil: 

Haven't tested the latest version with this Arteria service, but the "new" version only includes a new function that can validate the state of a runfolder, and adds a new state `ready` that can be used: https://github.com/arteria-project/arteria-core/compare/v1.0.1...master so shouldn't be a problem. 