### PR TITLE
FS is the real naming convention for iSeqs

### DIFF
--- a/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/lib/bcl2fastq_utils.py
@@ -137,7 +137,7 @@ class Bcl2FastqConfig:
                                  "A": "NovaSeq",
                                  "NS": "NextSeq 500",
                                  "K": "HiSeq 4000",
-                                 "FFSP": "ISeq 100"}
+                                 "FS": "ISeq 100"}
 
         for key, value in machine_type_mappings.items():
             if instrument_name.startswith(key):


### PR DESCRIPTION
**What problems does this PR solve?**
The documentation regarding iSeq naming conventions was incorrect, the naming convention for iSeqs should be that they start with FS.

**How has the changes been tested?**
No other tests have been carried out.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
